### PR TITLE
Remove git variables and update template_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ From the root directory of this repository, run the below commands to build your
 cd packer
 
 ATLAS_USERNAME=YOUR_ATLAS_USERNAME
-GIT_USERNAME=YOUR_GIT_USERNAME
-GIT_PASSWORD=YOUR_GIT_PASSWORD
 GCE_PROJECT_ID=YOUR_GOOGLE_PROJECT_ID
 GCE_DEFAULT_ZONE=us-central1-a
 GCE_SOURCE_IMAGE=ubuntu-1404-trusty-v20160114e
@@ -36,8 +34,6 @@ packer push gce_nomad_client.json
 cd packer
 
 ATLAS_USERNAME=YOUR_ATLAS_USERNAME
-GIT_USERNAME=YOUR_GIT_USERNAME
-GIT_PASSWORD=YOUR_GIT_PASSWORD
 AWS_ACCESS_KEY_ID=YOUR_AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
 AWS_DEFAULT_REGION=us-east-1
@@ -95,7 +91,6 @@ Once your infrastructure is provisioned, grab a Nomad Server to `ssh` into from 
 
 Run the below commands to schedule your first job. This will schedule 5 docker containers on 5 different nodes using the `node_class` constraint. Each job contains a different number of tasks that will be scheduled by Nomad, the job types are defined below.
 
-classlogger_2000_consul_raw_exec
 - [Docker Driver](https://www.nomadproject.io/docs/drivers/docker.html) (`classlogger_n_docker.nomad`)
   - Schedules n number of docker containers
 - [Docker Driver](https://www.nomadproject.io/docs/drivers/docker.html) with Consul (`classlogger_n_consul_docker.nomad`)

--- a/packer/aws_consul_server.json
+++ b/packer/aws_consul_server.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":    "{{env `ATLAS_USERNAME`}}",
-    "git_username":      "{{env `GIT_USERNAME`}}",
-    "git_password":      "{{env `GIT_PASSWORD`}}",
     "aws_access_key":    "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_region":        "{{env `AWS_DEFAULT_REGION`}}",

--- a/packer/aws_nomad_client.json
+++ b/packer/aws_nomad_client.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":    "{{env `ATLAS_USERNAME`}}",
-    "git_username":      "{{env `GIT_USERNAME`}}",
-    "git_password":      "{{env `GIT_PASSWORD`}}",
     "aws_access_key":    "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_region":        "{{env `AWS_DEFAULT_REGION`}}",
@@ -79,8 +77,8 @@
         "sh /ops/{{user `scripts_dir`}}/collectd.sh",
         "sh /ops/{{user `scripts_dir`}}/docker.sh {{user `ssh_username`}}",
         "sh /ops/{{user `scripts_dir`}}/consul.sh {{user `config_dir`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_client.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_client.sh {{user `config_dir`}}",
         "sh /ops/{{user `scripts_dir`}}/dnsmasq.sh {{user `dns_listen_addr`}}",
         "sh /ops/{{user `scripts_dir`}}/results.sh",
         "sh /ops/{{user `scripts_dir`}}/cleanup.sh"

--- a/packer/aws_nomad_server.json
+++ b/packer/aws_nomad_server.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":    "{{env `ATLAS_USERNAME`}}",
-    "git_username":      "{{env `GIT_USERNAME`}}",
-    "git_password":      "{{env `GIT_PASSWORD`}}",
     "aws_access_key":    "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key":    "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "aws_region":        "{{env `AWS_DEFAULT_REGION`}}",
@@ -78,8 +76,8 @@
         "sh /ops/{{user `scripts_dir`}}/go.sh",
         "sh /ops/{{user `scripts_dir`}}/collectd.sh",
         "sh /ops/{{user `scripts_dir`}}/consul.sh {{user `config_dir`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_server.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_server.sh {{user `config_dir`}}",
         "sh /ops/{{user `scripts_dir`}}/dnsmasq.sh {{user `dns_listen_addr`}}",
         "sh /ops/{{user `scripts_dir`}}/results.sh",
         "sh /ops/{{user `scripts_dir`}}/cleanup.sh"

--- a/packer/gce_consul_server.json
+++ b/packer/gce_consul_server.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":   "{{env `ATLAS_USERNAME`}}",
-    "git_username":     "{{env `GIT_USERNAME`}}",
-    "git_password":     "{{env `GIT_PASSWORD`}}",
     "gce_project_id":   "{{env `GCE_PROJECT_ID`}}",
     "gce_zone":         "{{env `GCE_DEFAULT_ZONE`}}",
     "gce_source_image": "{{env `GCE_SOURCE_IMAGE`}}",

--- a/packer/gce_nomad_client.json
+++ b/packer/gce_nomad_client.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":   "{{env `ATLAS_USERNAME`}}",
-    "git_username":     "{{env `GIT_USERNAME`}}",
-    "git_password":     "{{env `GIT_PASSWORD`}}",
     "gce_project_id":   "{{env `GCE_PROJECT_ID`}}",
     "gce_zone":         "{{env `GCE_DEFAULT_ZONE`}}",
     "gce_source_image": "{{env `GCE_SOURCE_IMAGE`}}",
@@ -72,8 +70,8 @@
         "sh /ops/{{user `scripts_dir`}}/collectd.sh",
         "sh /ops/{{user `scripts_dir`}}/docker.sh {{user `ssh_username`}}",
         "sh /ops/{{user `scripts_dir`}}/consul.sh {{user `config_dir`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_client.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_client.sh {{user `config_dir`}}",
         "sh /ops/{{user `scripts_dir`}}/dnsmasq.sh {{user `dns_listen_addr`}}",
         "sh /ops/{{user `scripts_dir`}}/results.sh",
         "sh /ops/{{user `scripts_dir`}}/cleanup.sh"

--- a/packer/gce_nomad_server.json
+++ b/packer/gce_nomad_server.json
@@ -1,8 +1,6 @@
 {
   "variables": {
     "atlas_username":   "{{env `ATLAS_USERNAME`}}",
-    "git_username":     "{{env `GIT_USERNAME`}}",
-    "git_password":     "{{env `GIT_PASSWORD`}}",
     "gce_project_id":   "{{env `GCE_PROJECT_ID`}}",
     "gce_zone":         "{{env `GCE_DEFAULT_ZONE`}}",
     "gce_source_image": "{{env `GCE_SOURCE_IMAGE`}}",
@@ -71,8 +69,8 @@
         "sh /ops/{{user `scripts_dir`}}/go.sh",
         "sh /ops/{{user `scripts_dir`}}/collectd.sh",
         "sh /ops/{{user `scripts_dir`}}/consul.sh {{user `config_dir`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
-        "sh /ops/{{user `scripts_dir`}}/nomad_server.sh {{user `config_dir`}} {{user `git_username`}} {{user `git_password`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_master.sh {{user `config_dir`}}",
+        "sh /ops/{{user `scripts_dir`}}/nomad_server.sh {{user `config_dir`}}",
         "sh /ops/{{user `scripts_dir`}}/dnsmasq.sh {{user `dns_listen_addr`}}",
         "sh /ops/{{user `scripts_dir`}}/results.sh",
         "sh /ops/{{user `scripts_dir`}}/cleanup.sh"

--- a/packer/scripts/consul_master.sh
+++ b/packer/scripts/consul_master.sh
@@ -9,8 +9,6 @@ logger() {
 logger "Executing"
 
 CONFIGDIR=/ops/$1/consul
-GITUSERNAME=$2
-GITPASSWORD=$3
 GODIR=/usr/local
 GOROOT=$GODIR/go
 GOPATH=/opt/go
@@ -30,7 +28,7 @@ CONSULCONFIGDIR=/etc/consul.d
 CONSULDIR=/opt/consul
 
 logger "Pulling $ORG/$REPO repo"
-sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT $GITUSERNAME $GITPASSWORD
+sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT
 
 logger "Building $REPO binaries in $REPOPATH/bin"
 cd $REPOPATH

--- a/packer/scripts/nomad_client.sh
+++ b/packer/scripts/nomad_client.sh
@@ -9,8 +9,6 @@ logger() {
 logger "Executing"
 
 CONFIGDIR=/ops/$1
-GITUSERNAME=$2
-GITPASSWORD=$3
 GODIR=/usr/local
 GOROOT=$GODIR/go
 GOPATH=/opt/go
@@ -27,7 +25,7 @@ ORGPATH=$GOSRC/github.com/$ORG
 REPOPATH=$ORGPATH/$REPO/schedbench
 
 logger "Pulling $ORG/$REPO repo"
-sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT $GITUSERNAME $GITPASSWORD
+sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT
 
 logger "Building $REPO binaries in $REPOPATH/bin"
 cd ${REPOPATH}/tests/nomad

--- a/packer/scripts/nomad_master.sh
+++ b/packer/scripts/nomad_master.sh
@@ -9,8 +9,6 @@ logger() {
 logger "Executing"
 
 CONFIGDIR=/ops/$1/nomad
-GITUSERNAME=$2
-GITPASSWORD=$3
 GODIR=/usr/local
 GOROOT=$GODIR/go
 GOPATH=/opt/go
@@ -30,7 +28,7 @@ NOMADCONFIGDIR=/etc/nomad.d
 NOMADDIR=/opt/nomad
 
 logger "Pulling $ORG/$REPO repo"
-sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT $GITUSERNAME $GITPASSWORD
+sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT
 
 logger "Building $REPO binaries in $REPOPATH/bin"
 cd $REPOPATH

--- a/packer/scripts/nomad_server.sh
+++ b/packer/scripts/nomad_server.sh
@@ -9,8 +9,6 @@ logger() {
 logger "Executing"
 
 CONFIGDIR=/ops/$1
-GITUSERNAME=$2
-GITPASSWORD=$3
 GODIR=/usr/local
 GOROOT=$GODIR/go
 GOPATH=/opt/go
@@ -27,7 +25,7 @@ ORGPATH=$GOSRC/github.com/$ORG
 REPOPATH=$ORGPATH/$REPO/schedbench
 
 logger "Pulling $ORG/$REPO repo"
-sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT $GITUSERNAME $GITPASSWORD
+sh /ops/packer/scripts/git_repo.sh $ORG $REPO $CHECKOUT
 
 logger "Building $REPO binaries in $REPOPATH/bin"
 cd ${REPOPATH}

--- a/terraform/templates/mount_ssd/mount_ssd.tf
+++ b/terraform/templates/mount_ssd/mount_ssd.tf
@@ -2,7 +2,7 @@ variable "mount_dir"      { }
 variable "local_ssd_name" { }
 
 resource "template_file" "mount_ssd" {
-  template = "${path.module}/mount_ssd.sh.tpl"
+  template = "${file("${path.module}/mount_ssd.sh.tpl")}"
 
   vars {
     mount_dir      = "${var.mount_dir}"

--- a/terraform/templates/nomad_job/classlogger/classlogger.tf
+++ b/terraform/templates/nomad_job/classlogger/classlogger.tf
@@ -4,7 +4,7 @@ variable "count"      { }
 variable "image"      { }
 
 resource "template_file" "docker" {
-  template = "${path.module}/docker.nomad.tpl"
+  template = "${file("${path.module}/docker.nomad.tpl")}"
 
   vars {
     region     = "${var.region}"
@@ -15,7 +15,7 @@ resource "template_file" "docker" {
 }
 
 resource "template_file" "consul_docker" {
-  template = "${path.module}/consul_docker.nomad.tpl"
+  template = "${file("${path.module}/consul_docker.nomad.tpl")}"
 
   vars {
     region     = "${var.region}"
@@ -26,7 +26,7 @@ resource "template_file" "consul_docker" {
 }
 
 resource "template_file" "raw_exec" {
-  template = "${path.module}/raw_exec.nomad.tpl"
+  template = "${file("${path.module}/raw_exec.nomad.tpl")}"
 
   vars {
     region     = "${var.region}"
@@ -36,7 +36,7 @@ resource "template_file" "raw_exec" {
 }
 
 resource "template_file" "consul_raw_exec" {
-  template = "${path.module}/consul_raw_exec.nomad.tpl"
+  template = "${file("${path.module}/consul_raw_exec.nomad.tpl")}"
 
   vars {
     region     = "${var.region}"

--- a/terraform/templates/nomad_job/redis/redis.tf
+++ b/terraform/templates/nomad_job/redis/redis.tf
@@ -4,7 +4,7 @@ variable "count"      { }
 variable "image"      { }
 
 resource "template_file" "redis" {
-  template = "${path.module}/redis.nomad.tpl"
+  template = "${file("${path.module}/redis.nomad.tpl")}"
 
   vars {
     region     = "${var.region}"

--- a/terraform/templates/nomad_job/web/web.tf
+++ b/terraform/templates/nomad_job/web/web.tf
@@ -6,7 +6,7 @@ variable "nodejs_count" { }
 variable "nodejs_image" { }
 
 resource "template_file" "web" {
-  template = "${path.module}/web.nomad.tpl"
+  template = "${file("${path.module}/web.nomad.tpl")}"
 
   vars {
     region       = "${var.region}"

--- a/terraform/templates/pq/pq.tf
+++ b/terraform/templates/pq/pq.tf
@@ -2,7 +2,7 @@ variable "service"          { }
 variable "consul_join_name" { }
 
 resource "template_file" "pq" {
-  template = "${path.module}/pq.sh.tpl"
+  template = "${file("${path.module}/pq.sh.tpl")}"
 
   vars {
     service          = "${var.service}"


### PR DESCRIPTION
Git credentials were necessary for when the repo's weren't public, removing now.

Also, Terraform 0.6.13 throws a warning for using a file path for the `template_file` resource's `template` argument without using the `file` interpolation for the path, updated that as well.